### PR TITLE
Allow detection of the device on ACM[0-9]* port

### DIFF
--- a/src/Loupedeck/DeviceManager.py
+++ b/src/Loupedeck/DeviceManager.py
@@ -25,7 +25,7 @@ class DeviceManager:
             ports = [f"COM{i}" for i in range(1, 256)]
         elif sys.platform.startswith("linux") or sys.platform.startswith("cygwin"):
             # this excludes your current terminal "/dev/tty"
-            ports = glob.glob("/dev/tty[A-Za-z]*")
+            ports = glob.glob("/dev/tty[A-Za-z0-9]*")
         elif sys.platform.startswith("darwin"):
             ports = glob.glob("/dev/tty.*")
         else:


### PR DESCRIPTION
On some linux systems, plugging the loupedeck to the computer will result in it being assigned to an ACM[0-9] port in /dev (in my case ACM0 for example). The current detection string for linux `tty[A-Za-z]*` is therefore not able to detect it.
I modified the string accordingly in order to allow the detection of the loupedeck device on such systems.