### PR TITLE
Fix macOS enumeration hang on composite USB devices

### DIFF
--- a/src/Loupedeck/DeviceManager.py
+++ b/src/Loupedeck/DeviceManager.py
@@ -4,11 +4,16 @@ Main Loupedeck and LoupedeckLive classes.
 import glob
 import logging
 import serial
+import serial.tools.list_ports
 import sys
 from .Devices import LoupedeckLive
 
 logger = logging.getLogger("DeviceManager")
 VERBOSE = False
+
+# Loupedeck USB vendor ID; used to pre-filter ports before probing.
+LOUPEDECK_VID = 0x2EC2
+
 
 class DeviceManager:
 
@@ -21,6 +26,27 @@ class DeviceManager:
             :returns:
                 A list of the serial ports available on the system
         """
+        # Fast path: use pyserial's cross-platform port enumerator which carries
+        # USB VID/PID metadata.  Filtering by Loupedeck's vendor ID avoids
+        # opening unrelated ports (Bluetooth, MIDI, etc.) and, critically,
+        # prevents the is_loupedeck() probe from being run against devices that
+        # continuously emit binary data — which would previously cause an
+        # infinite hang on macOS composite USB devices.
+        try:
+            vid_filtered = [
+                p.device
+                for p in serial.tools.list_ports.comports()
+                if p.vid == LOUPEDECK_VID
+            ]
+            if vid_filtered:
+                logger.debug(f"list: VID filter found {len(vid_filtered)} Loupedeck-VID port(s): {vid_filtered}")
+                return vid_filtered
+            logger.debug("list: VID filter found no Loupedeck-VID ports; falling back to full scan")
+        except Exception as exc:
+            logger.warning(f"list: VID/PID port scan failed ({exc}); falling back to full scan")
+
+        # Fallback: original glob-based scan for platforms where pyserial's
+        # list_ports does not return VID metadata.
         if sys.platform.startswith("win"):
             ports = [f"COM{i}" for i in range(1, 256)]
         elif sys.platform.startswith("linux") or sys.platform.startswith("cygwin"):

--- a/src/Loupedeck/Devices/Loupedeck.py
+++ b/src/Loupedeck/Devices/Loupedeck.py
@@ -100,14 +100,20 @@ class Loupedeck:
         logger.debug(f"is_loupedeck: {self.path}: trying..")
         while not self.inited and good < len(WS_UPGRADE_RESPONSE):
             raw_byte = self.connection.readline()
-            logger.debug(f"is_loupedeck: {raw_byte}")
-            if raw_byte in WS_UPGRADE_RESPONSE:  # got entire WS_UPGRADE_RESPONSE
+            logger.debug(f"is_loupedeck: {self.path}: read {len(raw_byte)} bytes: {raw_byte!r}")
+            if raw_byte in WS_UPGRADE_RESPONSE:  # got one expected WS upgrade line
                 good = good + 1
-            if raw_byte == b"":
+                logger.debug(f"is_loupedeck: {self.path}: good={good}/{len(WS_UPGRADE_RESPONSE)}")
+            else:
+                # Count ANY non-matching response (empty timeout or unexpected data).
+                # Previously only b"" was counted, causing an infinite loop when
+                # a port continuously emits non-matching binary data (e.g. MIDI,
+                # wrong interface, or device in unexpected state on macOS).
                 cnt = cnt + 1
+                logger.debug(f"is_loupedeck: {self.path}: non-matching response #{cnt} (max={NUM_ATTEMPTS + 1})")
             if cnt > NUM_ATTEMPTS:
                 logger.debug(
-                    f"is_loupedeck: {self.path}: ..got {cnt} wrong answers, probably not a {type(self).__name__} device, ignoring."
+                    f"is_loupedeck: {self.path}: ..got {cnt} non-matching responses, probably not a {type(self).__name__} device, ignoring."
                 )
                 self.inited = True
         if good == len(WS_UPGRADE_RESPONSE):  # not 100% correct, but ok.


### PR DESCRIPTION
## Problem

`is_loupedeck()` could hang indefinitely on macOS when a serial port continuously emitted non-empty, non-matching bytes (e.g. a wrong interface on a composite USB device, or a busy port). Only `b""` (a timeout read) incremented the bail-out counter, so any other data left both counters unchanged and the while loop never exited.

## Fix

1. **Pre-filter by USB vendor ID** — use `serial.tools.list_ports` to restrict candidates to ports with Loupedeck's VID (0x2EC2) before probing. The original glob-based scan is kept as a fallback for platforms where pyserial doesn't return VID metadata.

2. **Count any non-matching response** — `is_loupedeck()` now increments the bail-out counter on *any* non-matching `readline()` result, not just empty reads, so two unexpected bytes bail out as quickly as two timeouts.

## Files changed

- `src/Loupedeck/DeviceManager.py` — VID pre-filter with fallback
- `src/Loupedeck/Devices/Loupedeck.py` — fix bail-out counter logic